### PR TITLE
chore(tasks): use remote tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 .env.*
 !.env.example
+.task/
 .DS_Store
 __pycache__
 .idea

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -2,21 +2,22 @@ version: "3"
 output: interleaved
 dotenv: [".env.local"]
 
+includes:
+  index: https://raw.githubusercontent.com/livekit-examples/index/main/taskfile.yaml
+
 tasks:
   post_create:
     desc: "Runs after this template is instantiated as a Sandbox or Bootstrap"
     cmds:
-      - echo -e "To try the new agent directly in your terminal:\r\n"
-      - echo -e "\tcd {{.ROOT_DIR}}\r"
-      - echo -e "\tuv sync\r"
-      - echo -e "\tuv run src/agent.py download-files\r"
-      - echo -e "\tuv run src/agent.py console\r\n"
+      - task: index:help_setup_python_uv
+      - task: index:help_deploy_agent
 
   install:
     desc: "Bootstrap application for local development"
     cmds:
-      - "uv sync"
+      - task: index:install_python_uv
+
   dev:
     interactive: true
     cmds:
-      - "uv run src/agent.py dev"
+      - task: index:dev_python_uv


### PR DESCRIPTION
This patch updates the taskfile to use the remote tasks defined in the [index](https://github.com/livekit-examples/index/blob/main/taskfile.yaml) to allow us to update common tasks from a single source of truth. 

It also adds some messaging on agent deployment, so that once we go GA, users will get a nice little helper message after bootstrapping an agent template:

```
To setup and run locally:

    cd <my_app>
    uv sync
    uv run src/agent.py download-files
    uv run src/agent.py console

To deploy your agent to LiveKit cloud:

    lk agent create

```