### PR TITLE
bump minimum python version to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "agent-starter-python"
 version = "1.0.0"
 description = "Simple voice AI assistant built with LiveKit Agents for Python"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 dependencies = [
     "livekit-agents[silero,turn-detector]~=1.2",


### PR DESCRIPTION
When running with 3.9 on macOS, I get the following:

```
❯ uv sync
Using CPython 3.9.6 interpreter at: /Applications/Xcode.app/Contents/Developer/usr/bin/python3
Creating virtual environment at: .venv
Resolved 103 packages in 28.53s
error: Distribution `onnxruntime==1.20.1 @ registry+https://pypi.org/simple` can't be installed because it doesn't have a source distribution or wheel for the current platform

hint: You're using CPython 3.9 (`cp39`), but `onnxruntime` (v1.20.1) only has wheels with the following Python implementation tags: `cp310`, `cp311`, `cp312`, `cp313`
```

Bumping the version to 3.10 seems to fix this. I'm not a regular python user so this could be something related to my setup but I'm making this PR in case someone finds it helpful