### PR TITLE
Upgrade LLM model from GPT-5.2 to GPT-5.3

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -72,7 +72,7 @@ async def my_agent(ctx: JobContext):
         stt=inference.STT(model="deepgram/nova-3", language="multi"),
         # A Large Language Model (LLM) is your agent's brain, processing user input and generating a response
         # See all available models at https://docs.livekit.io/agents/models/llm/
-        llm=inference.LLM(model="openai/gpt-5.2-chat-latest"),
+        llm=inference.LLM(model="openai/gpt-5.3-chat-latest"),
         # Text-to-speech (TTS) is your agent's voice, turning the LLM's text into speech that the user can hear
         # See all available models as well as voice selections at https://docs.livekit.io/agents/models/tts/
         tts=inference.TTS(


### PR DESCRIPTION
## Summary
- Update LLM model from `openai/gpt-5.2-chat-latest` to `openai/gpt-5.3-chat-latest` in agent pipeline
