### PR TITLE
Enable Python bytecode compilation during build to reduce cold-start time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,11 @@ FROM ghcr.io/astral-sh/uv:python${PYTHON_VERSION}-bookworm-slim AS base
 # the application crashes without emitting any logs due to buffering.
 ENV PYTHONUNBUFFERED=1
 
+# Compile Python source to bytecode (.pyc) during install so the first import
+# doesn't pay the compilation cost. This reduces agent cold-start time at the
+# expense of a slightly longer build.
+ENV UV_COMPILE_BYTECODE=1
+
 # --- Build stage ---
 # Install dependencies, build native extensions, and prepare the application
 FROM base AS build


### PR DESCRIPTION
## Summary
This change enables Python bytecode compilation during the Docker build process to improve agent cold-start performance by pre-compiling Python source files to `.pyc` format.

## Key Changes
- Added `UV_COMPILE_BYTECODE=1` environment variable to the base Docker stage
- This instructs the `uv` package manager to compile all Python source code to bytecode during dependency installation

## Implementation Details
By pre-compiling Python source to bytecode during the build phase, the first import of Python modules no longer incurs the compilation cost at runtime. This reduces cold-start latency for the agent, though it comes at the trade-off of a slightly longer build time. The bytecode compilation happens once during image build rather than on every container startup.

https://claude.ai/code/session_01Noyea9Jyi7sgN1ctUhpZJf