### PR TITLE
Cache download-files in Dockerfile by using the module-level command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,15 +48,16 @@ RUN mkdir -p src
 # Ensure your uv.lock file is checked in for consistency across environments
 RUN uv sync --locked
 
+# Pre-download any ML models or files the agent needs
+# This runs before COPY . . so the download layer is cached across code-only changes.
+# The module-level command discovers installed livekit-plugins-* packages without
+# loading your agent code.
+RUN uv run --module livekit.agents download-files
+
 # Copy all remaining application files into the container
 # This includes source code, configuration files, and dependency specifications
 # (Excludes files specified in .dockerignore)
 COPY . .
-
-# Pre-download any ML models or files the agent needs
-# This ensures the container is ready to run immediately without downloading
-# dependencies at runtime, which improves startup time and reliability
-RUN uv run "src/agent.py" download-files
 
 # --- Production stage ---
 # Build tools (gcc, g++, python3-dev) are not included in the final image


### PR DESCRIPTION
## Overview

Update the Dockerfile to use the module-level `download-files` command introduced in `livekit-agents@1.5.10`. The download step now runs before `COPY . .`, so the layer caches across code-only changes — editing your agent no longer triggers a re-download of plugin model files.

## Change

`RUN uv run "src/agent.py" download-files` (after `COPY . .`) → `RUN uv run --module livekit.agents download-files` (before `COPY . .`).

The new command discovers installed `livekit-plugins-*` packages and runs their `download_files()` step without loading your agent code. That's what allows the step to move ahead of the source copy.

`livekit-agents` is pinned to 1.5.12 in `pyproject.toml`, which is past the 1.5.10 threshold for the module-level command.

## Related PRs

This is part of a coordinated rollout across five repos. Each PR updates one slice of the same migration.

- Docs: livekit/web#4545
- CLI templates: livekit/livekit-cli#848
- Python starter (this PR): livekit-examples/agent-starter-python#79
- Node.js starter: livekit-examples/agent-starter-node#49
- Agent builder export: livekit/cloud-api-server#1847

Upstream SDK changes:

- Python: livekit/agents#5738 (livekit-agents@1.5.10)
- Node.js: livekit/agents-js#1511 (@livekit/agents@1.4.3)

