### PR TITLE
chore: bump livekit-agents to 1.5.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Simple voice AI assistant built with LiveKit Agents for Python"
 requires-python = ">=3.10, <3.15"
 
 dependencies = [
-    "livekit-agents[silero,turn-detector]==1.5.12",
+    "livekit-agents[silero,turn-detector]==1.5.16",
     "livekit-plugins-ai-coustics~=0.2",
     "python-dotenv",
 ]


### PR DESCRIPTION
Automated bump from [`livekit/agents`](https://github.com/livekit/agents).

Updates:
- `livekit-agents` → `1.5.16`