### PR TITLE
Fix dependency version specification for livekit-agents

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Simple voice AI assistant built with LiveKit Agents for Python"
 requires-python = ">=3.10, <3.15"
 
 dependencies = [
-    "livekit-agents[silero,turn-detector]==1.5.17",
+    "livekit-agents[silero,turn-detector]^=1.5.17",
     "livekit-plugins-ai-coustics~=0.2",
     "python-dotenv",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Simple voice AI assistant built with LiveKit Agents for Python"
 requires-python = ">=3.10, <3.15"
 
 dependencies = [
-    "livekit-agents[silero,turn-detector]^=1.5.17",
+    "livekit-agents[silero,turn-detector]>=1.5.17",
     "livekit-plugins-ai-coustics~=0.2",
     "python-dotenv",
 ]


### PR DESCRIPTION
quick fix to ensure we're not pinning users to a specific version and preventing them from receiving future patches