### PR TITLE
docs: use long-form flags in lk app env example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can load the LiveKit environment automatically using the [LiveKit CLI](https
 
 ```bash
 lk cloud auth
-lk app env -w -d .env.local
+lk app env --write --destination .env.local
 ```
 
 </details>


### PR DESCRIPTION
## Summary
- Replace short flags (`-w -d`) with long-form (`--write --destination`) in the `lk app env` example in the README for clarity.

## Test plan
- [ ] Verify rendered README reads clearly