### PR TITLE
post_create: skip install hint when deps already installed

### DIFF
--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -21,6 +21,14 @@ tasks:
       - task: set_agent_name_if_present
       - task: help_open_sandbox_if_present
 
+  help_install_hint_if_needed:
+    desc: "Print the local install hint, unless the CLI already installed dependencies"
+    status:
+      # Skip when `lk agent init --install` already ran the install task.
+      - test -n "$LIVEKIT_DEPS_INSTALLED"
+    cmds:
+      - echo '{{ indent .INDENT "uv sync" }}'
+
   set_agent_name_if_present:
     status:
       - test -z "$LIVEKIT_AGENT_NAME"
@@ -42,7 +50,7 @@ tasks:
       - echo 'To try your new agent directly in your terminal:'
       - echo ''
       - echo '{{ indent .INDENT "cd" }} {{ .REL_PATH }}'
-      - echo '{{ indent .INDENT "uv sync" }}'
+      - task: help_install_hint_if_needed
       - echo '{{ indent .INDENT "uv run" }} {{ .PYTHON_MAIN }} console'
 
   help_open_web_console:
@@ -55,7 +63,7 @@ tasks:
       - echo 'To try your new agent in the web console:'
       - echo ''
       - echo '{{ indent .INDENT "cd" }} {{ .REL_PATH }}'
-      - echo '{{ indent .INDENT "uv sync" }}'
+      - task: help_install_hint_if_needed
       - echo '{{ indent .INDENT "uv run" }} {{ .PYTHON_MAIN }} dev'
       - echo ''
       - echo 'Then visit:'


### PR DESCRIPTION
## Summary

When a user runs `lk agent init --install` (or answers "yes" to *Install dependencies?*), the CLI already runs the `install` task (`uv sync`). The `post_create` "next steps" then still print `uv sync`, which is redundant.

This moves the install hint into a small guarded subtask that is **skipped when the CLI already installed dependencies**, using the same `status:` pattern already used for `LIVEKIT_AGENT_NAME` / `LIVEKIT_SANDBOX_ID`. The hint appears in two blocks (`help_run_console` and `help_open_web_console`), so both now call the shared subtask.

```yaml
  help_install_hint_if_needed:
    status:
      - test -n "$LIVEKIT_DEPS_INSTALLED"    # skip when CLI already installed
    cmds:
      - echo '{{ indent .INDENT "uv sync" }}'
```

The CLI sets `LIVEKIT_DEPS_INSTALLED=1` after a successful install (livekit/livekit-cli#884). Until that ships, the var is never set, so behavior is unchanged.

## Behavior

| Scenario | `uv sync` shown? |
| --- | --- |
| `lk agent init` (no install) | ✅ yes (unchanged) |
| `lk agent init --install` (success) | ❌ skipped |

## Testing

Verified end-to-end against a local CLI build: the hint is omitted on a successful `--install` and retained when install isn't run.

> Companion CLI PR: livekit/livekit-cli#884 · sibling: livekit-examples/agent-starter-node#55