### PR TITLE
Change default LLM model from 5.2-chat to Gemma 31B

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -24,7 +24,7 @@ class Assistant(Agent):
         super().__init__(
             # A Large Language Model (LLM) is your agent's brain, processing user input and generating a response
             # See all available models at https://docs.livekit.io/agents/models/llm/
-            llm=inference.LLM(model="openai/gpt-5.2-chat-latest"),
+            llm=inference.LLM(model="google/gemma-4-31b-it"),
             # To use a realtime model instead of a voice pipeline, replace the LLM
             # with a RealtimeModel and remove the STT/TTS from the AgentSession
             # (Note: This is for the OpenAI Realtime API. For other providers, see https://docs.livekit.io/agents/models/realtime/)


### PR DESCRIPTION
Changing the default LLM to our latency optimized `google/gemma-4-31b-it` deployment.