### PR TITLE
Enable keyterms by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The starter project includes:
   - Supports more than 50 models from OpenAI, Cartesia, Deepgram, and other providers
   - Access to a wide range of other models, including [Realtime models](https://docs.livekit.io/agents/models/realtime), through extensive plugin ecosystem
 - Expressive mode, enabled by default: the framework injects the TTS provider's markup guide into the LLM prompt, so the model emits inline delivery tags (emotion, pacing, non-verbal sounds) that the TTS renders and the transcript never shows
+- [Keyterms](https://docs.livekit.io/agents/models/stt/keyterms/), enabled by default: static terms bias the STT toward your own names, brands, and jargon, and automatic detection picks up distinctive spellings from the live conversation
 - Eval suite based on the LiveKit Agents [testing & evaluation framework](https://docs.livekit.io/agents/start/testing/)
 - [LiveKit Turn Detector](https://docs.livekit.io/agents/logic/turns/turn-detector/), an end-of-turn model that listens to the user's audio directly, combining semantic understanding with acoustic cues for state-of-the-art accuracy across 14 languages
 - [Background voice cancellation](https://docs.livekit.io/transport/media/noise-cancellation/)

--- a/src/agent.py
+++ b/src/agent.py
@@ -7,6 +7,7 @@ from livekit.agents import (
     AgentServer,
     AgentSession,
     JobContext,
+    STTContextOptions,
     TurnHandlingOptions,
     cli,
     inference,
@@ -104,6 +105,15 @@ async def my_agent(ctx: JobContext):
         # Speech-to-text (STT) is your agent's ears, turning the user's speech into text that the LLM can understand
         # See all available models at https://docs.livekit.io/agents/models/stt/
         stt=inference.STT(model="assemblyai/universal-3-5-pro", language="en"),
+        # Keyterms bias the STT toward distinctive words it would otherwise misspell.
+        # List your own names, brands, and jargon in `keyterms`. Detection additionally
+        # extracts terms from the live conversation, such as a caller's name, and applies
+        # them once the transcript corroborates the spelling.
+        # See more at https://docs.livekit.io/agents/models/stt/keyterms/
+        stt_context_options=STTContextOptions(
+            keyterms=["LiveKit"],
+            keyterm_detection={"enabled": True},
+        ),
         # Text-to-speech (TTS) is your agent's voice, turning the LLM's text into speech that the user can hear
         # See all available models as well as voice selections at https://docs.livekit.io/agents/models/tts/
         tts=inference.TTS(


### PR DESCRIPTION
Adds static keyterms plus automatic keyterm detection.

Static terms bias the STT toward names, brands, and jargon the developer knows up front; detection picks up distinctive spellings from the live conversation. The AssemblyAI model already configured here maps the managed set to its native keyterms_prompt parameter.