### PR TITLE
Use "Voice isolation" for the noise cancellation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The starter project includes:
 - Expressive mode, enabled by default: the framework injects the TTS provider's markup guide into the LLM prompt, so the model emits inline delivery tags (emotion, pacing, non-verbal sounds) that the TTS renders and the transcript never shows
 - Eval suite based on the LiveKit Agents [testing & evaluation framework](https://docs.livekit.io/agents/start/testing/)
 - [LiveKit Turn Detector](https://docs.livekit.io/agents/logic/turns/turn-detector/), an end-of-turn model that listens to the user's audio directly, combining semantic understanding with acoustic cues for state-of-the-art accuracy across 14 languages
-- [Background voice cancellation](https://docs.livekit.io/transport/media/noise-cancellation/)
+- [Voice isolation](https://docs.livekit.io/transport/media/noise-cancellation/)
 - Deep session insights from LiveKit [Agent Observability](https://docs.livekit.io/deploy/observability/)
 - A Dockerfile ready for [production deployment to LiveKit Cloud](https://docs.livekit.io/deploy/agents/)
 


### PR DESCRIPTION
## Summary

The feature list calls the noise cancellation feature "Background voice cancellation." That's Krisp's retired product name — the current term is **Voice isolation**, which is what the pricing page, the [noise cancellation docs](https://docs.livekit.io/transport/media/noise-cancellation/), and the plugin API (`voice_isolation()`) all use.

It's also not what this starter configures. `src/agent.py` uses `ai_coustics.audio_enhancement(model=EnhancerModel.QUAIL_VF_S)`, an ai-coustics Voice Focus model, so "Background voice cancellation" names neither the feature nor the provider correctly.

## Context

Part of [DOCS-1927](https://linear.app/livekit/issue/DOCS-1927/standardize-krisp-viva-terminology-across-docs-surfaces), which standardizes this terminology across surfaces. The docs-side changes are in [livekit/web#5887](https://github.com/livekit/web/pull/5887); this README line was the one instance outside that repo.

## Changes

- README feature list: "Background voice cancellation" → "Voice isolation". The link target is unchanged.
