### PR TITLE
[wip] Add session observability with tags and LLM-based evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The starter project includes:
 - Eval suite based on the LiveKit Agents [testing & evaluation framework](https://docs.livekit.io/agents/start/testing/)
 - [LiveKit Turn Detector](https://docs.livekit.io/agents/logic/turns/turn-detector/) for contextually-aware speaker detection, with multilingual support
 - [Background voice cancellation](https://docs.livekit.io/transport/media/noise-cancellation/)
-- Deep session insights from LiveKit [Agent Observability](https://docs.livekit.io/deploy/observability/)
+- Deep session insights from LiveKit [Agent Observability](https://docs.livekit.io/deploy/observability/), including [session tags](https://docs.livekit.io/deploy/observability/tags/) and [production evals](https://docs.livekit.io/deploy/observability/evals/)
 - A Dockerfile ready for [production deployment to LiveKit Cloud](https://docs.livekit.io/deploy/agents/)
 
 This starter app is compatible with any [custom web/mobile frontend](https://docs.livekit.io/frontends/) or [telephony](https://docs.livekit.io/telephony/).

--- a/src/agent.py
+++ b/src/agent.py
@@ -99,7 +99,32 @@ def prewarm(proc: JobProcess):
 server.setup_fnc = prewarm
 
 
-@server.rtc_session(agent_name="my-agent")
+async def on_session_end(ctx: JobContext) -> None:
+    # Agent Observability: tag the session so you can find and analyze it in LiveKit Cloud.
+    # Tags and outcomes appear on the session's Insights timeline.
+    # Tags: https://docs.livekit.io/deploy/observability/tags/
+    # Production evals (LLM-as-judge): https://docs.livekit.io/deploy/observability/evals/
+    try:
+        report = ctx.make_session_report()
+    except RuntimeError:
+        # The session never started (for example, the job failed during setup),
+        # so there's nothing to tag.
+        return
+
+    # Mark whether the user actually engaged in a conversation.
+    chat = report.chat_history.copy(
+        exclude_function_call=True, exclude_instructions=True
+    )
+    if len(chat.items) >= 3:
+        ctx.tagger.success()
+    else:
+        ctx.tagger.fail(reason="No meaningful conversation")
+
+    # You can also add your own custom tags with optional metadata, for example:
+    # ctx.tagger.add("turns", metadata={"count": len(chat.items)})
+
+
+@server.rtc_session(agent_name="my-agent", on_session_end=on_session_end)
 async def my_agent(ctx: JobContext):
     # Logging setup
     # Add any other context you want in all log entries here

--- a/src/agent.py
+++ b/src/agent.py
@@ -12,6 +12,12 @@ from livekit.agents import (
     inference,
     room_io,
 )
+from livekit.agents.evals import (
+    JudgeGroup,
+    coherence_judge,
+    conciseness_judge,
+    safety_judge,
+)
 from livekit.plugins import ai_coustics
 
 logger = logging.getLogger("agent")
@@ -103,17 +109,34 @@ async def on_session_end(ctx: JobContext) -> None:
         # so there's nothing to tag.
         return
 
-    # Mark whether the user actually engaged in a conversation.
+    # Mark whether the user actually engaged in a conversation. This is a cheap,
+    # instant heuristic — no model call — so it runs on every session.
     chat = report.chat_history.copy(
         exclude_function_call=True, exclude_instructions=True
     )
-    if len(chat.items) >= 3:
-        ctx.tagger.success()
-    else:
+    if len(chat.items) < 3:
         ctx.tagger.fail(reason="No meaningful conversation")
+        return
+
+    ctx.tagger.success()
 
     # You can also add your own custom tags with optional metadata, for example:
     # ctx.tagger.add("turns", metadata={"count": len(chat.items)})
+
+    # Production evals: score the conversation with LLM-as-judge. Each verdict is
+    # tagged automatically as `lk.judge.<name>`, so you can filter and analyze
+    # sessions by quality in LiveKit Cloud.
+    # https://docs.livekit.io/deploy/observability/evals/
+    #
+    # Judging runs an LLM per session, so it's gated behind the engagement check
+    # above — empty or abandoned sessions don't incur a model call. These built-in
+    # judges suit a general assistant; swap in others (accuracy, task_completion,
+    # tool_use, handoff) or a custom `Judge` subclass as your agent grows.
+    judges = JudgeGroup(
+        llm="openai/gpt-4o-mini",
+        judges=[safety_judge(), coherence_judge(), conciseness_judge()],
+    )
+    await judges.evaluate(report.chat_history)
 
 
 @server.rtc_session(agent_name="my-agent", on_session_end=on_session_end)

--- a/src/agent.py
+++ b/src/agent.py
@@ -14,8 +14,8 @@ from livekit.agents import (
 )
 from livekit.agents.evals import (
     JudgeGroup,
-    coherence_judge,
     conciseness_judge,
+    relevancy_judge,
     safety_judge,
 )
 from livekit.plugins import ai_coustics
@@ -109,32 +109,29 @@ async def on_session_end(ctx: JobContext) -> None:
         # so there's nothing to tag.
         return
 
-    # Mark whether the user actually engaged in a conversation. This is a cheap,
-    # instant heuristic — no model call — so it runs on every session.
+    # Mark whether the user actually engaged in a conversation.
     chat = report.chat_history.copy(
         exclude_function_call=True, exclude_instructions=True
     )
-    if len(chat.items) < 3:
+    if len(chat.items) >= 3:
+        ctx.tagger.success()
+    else:
         ctx.tagger.fail(reason="No meaningful conversation")
-        return
-
-    ctx.tagger.success()
 
     # You can also add your own custom tags with optional metadata, for example:
     # ctx.tagger.add("turns", metadata={"count": len(chat.items)})
 
-    # Production evals: score the conversation with LLM-as-judge. Each verdict is
+    # Production evals: score every session with LLM-as-judge. Each verdict is
     # tagged automatically as `lk.judge.<name>`, so you can filter and analyze
     # sessions by quality in LiveKit Cloud.
     # https://docs.livekit.io/deploy/observability/evals/
     #
-    # Judging runs an LLM per session, so it's gated behind the engagement check
-    # above — empty or abandoned sessions don't incur a model call. These built-in
-    # judges suit a general assistant; swap in others (accuracy, task_completion,
-    # tool_use, handoff) or a custom `Judge` subclass as your agent grows.
+    # These built-in judges suit a general assistant; swap in others (accuracy,
+    # coherence, task_completion, tool_use, handoff) or a custom `Judge` subclass
+    # as your agent grows. Each judge adds an LLM call per session.
     judges = JudgeGroup(
         llm="openai/gpt-4o-mini",
-        judges=[safety_judge(), coherence_judge(), conciseness_judge()],
+        judges=[safety_judge(), relevancy_judge(), conciseness_judge()],
     )
     await judges.evaluate(report.chat_history)
 


### PR DESCRIPTION
## Summary
Adds comprehensive session observability to the agent by implementing session end callbacks that tag conversations and evaluate quality using LLM-as-judge verdicts.

## Key Changes
- **New `on_session_end` callback**: Implements session lifecycle observability with:
  - Automatic success/failure tagging based on conversation engagement (3+ messages threshold)
  - LLM-based evaluation using built-in judges (safety, relevancy, conciseness)
  - Graceful handling of sessions that fail during setup
  
- **Judge integration**: Evaluates every session using `JudgeGroup` with three production-ready judges:
  - `safety_judge()` - Ensures responses are safe and appropriate
  - `relevancy_judge()` - Validates response relevance to user queries
  - `conciseness_judge()` - Checks response conciseness
  
- **Session registration**: Wires the callback into the agent via `on_session_end` parameter in `@server.rtc_session` decorator

- **Documentation update**: Enhanced README to explicitly mention session tags and production evals as key features

## Implementation Details
- Session reports are safely generated with error handling for sessions that never started
- Chat history is filtered to exclude function calls and system instructions for meaningful engagement detection
- Each judge verdict is automatically tagged as `lk.judge.<name>` for filtering and analysis in LiveKit Cloud
- The implementation follows the production evals pattern documented in LiveKit's observability guide

https://claude.ai/code/session_01Mkt7G86CNXSTmhRrwHcL2A